### PR TITLE
Add Text Overlay

### DIFF
--- a/NodeGraphQt/widgets/scene.py
+++ b/NodeGraphQt/widgets/scene.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-from qtpy import QtGui, QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from NodeGraphQt.constants import ViewerEnum
 
@@ -17,15 +16,6 @@ class NodeScene(QtWidgets.QGraphicsScene):
         cls_name = str(self.__class__.__name__)
         return '<{}("{}") object at {}>'.format(
             cls_name, self.viewer(), hex(id(self)))
-
-    # def _draw_text(self, painter, pen):
-    #     font = QtGui.QFont()
-    #     font.setPixelSize(48)
-    #     painter.setFont(font)
-    #     parent = self.viewer()
-    #     pos = QtCore.QPoint(20, parent.height() - 20)
-    #     painter.setPen(pen)
-    #     painter.drawText(parent.mapToScene(pos), 'Not Editable')
 
     def _draw_grid(self, painter, rect, pen, grid_size):
         """

--- a/examples/nodes/widget_nodes.py
+++ b/examples/nodes/widget_nodes.py
@@ -70,6 +70,7 @@ class TextInputNode(BaseNode):
             "tool_btn": tool_btn_kwargs,
         }
         node_widget = NodeLineEditValidatorCheckBox(
+            "src_path",
             pattern,
             placeholder,
             tooltip,
@@ -101,6 +102,7 @@ class TextInputNode(BaseNode):
             "tool_btn": tool_btn_kwargs,
         }
         node_widget2 = NodeLineEditValidatorCheckBox(
+            "dst_path",
             pattern,
             placeholder,
             tooltip,


### PR DESCRIPTION
Mimic Unreal Engine Blueprint/Material Editor text overlay

## Screenshots
![image](https://github.com/hueyyeng/NodeGraphQt/assets/15846423/2bef9960-5e53-448a-a7a5-e358de44a28c)

![image](https://github.com/hueyyeng/NodeGraphQt/assets/15846423/a0241389-d1a1-4abd-92ed-602056771615)
![image](https://github.com/hueyyeng/NodeGraphQt/assets/15846423/764b28e9-ca16-42bd-84fe-23c46d9500c0)

The font size is constant regardless of the viewer scene scale.